### PR TITLE
Limit max toast width to 500pt for compact desktop layout

### DIFF
--- a/Sources/NoticeUI/ToastView.swift
+++ b/Sources/NoticeUI/ToastView.swift
@@ -66,7 +66,8 @@ struct ToastView: View {
                 icon: toast.icon
             )
         )
-        .frame(maxWidth: .infinity)
+        .frame(maxWidth: 500)
+        .frame(maxWidth: .infinity, alignment: .center)
         .padding(.horizontal, 16)
     }
     


### PR DESCRIPTION
Closes #1

### Summary
Limits toast width to 500pt on macOS and iPad to prevent them from stretching across the full window, resulting in a cleaner, more compact appearance.

### Changes

- Set maxWidth: 500 on ToastView.
- Toasts now center-align on large screens while remaining full-width on iPhone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Toast notifications now display with a constrained maximum width and centered positioning for improved visual consistency and readability across varying screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->