### PR TITLE
Support macOS safe area insets using AppKit

### DIFF
--- a/Sources/NoticeUI/ToastView.swift
+++ b/Sources/NoticeUI/ToastView.swift
@@ -4,6 +4,10 @@ import SwiftUI
 import UIKit
 #endif
 
+#if canImport(AppKit)
+import AppKit
+#endif
+
 /// Internal view that renders a toast using the current style.
 ///
 /// `ToastView` is responsible for:
@@ -52,6 +56,13 @@ struct ToastView: View {
             return EdgeInsets()
         }
         let insets = window.safeAreaInsets
+        return EdgeInsets(top: insets.top, leading: insets.left, bottom: insets.bottom, trailing: insets.right)
+        #elseif canImport(AppKit)
+        guard let window = NSApplication.shared.keyWindow ?? NSApplication.shared.windows.first,
+              let contentView = window.contentView else {
+            return EdgeInsets()
+        }
+        let insets = contentView.safeAreaInsets
         return EdgeInsets(top: insets.top, leading: insets.left, bottom: insets.bottom, trailing: insets.right)
         #else
         return EdgeInsets()


### PR DESCRIPTION
Closes #2 

### Summary
Fixes an issue where toasts on macOS would ignore window safe areas and render flush against the title bar/traffic light buttons.

### Changes

- Added AppKit support to ToastView's safe area calculation.
- Implemented NSApplication.shared.keyWindow.contentView.safeAreaInsets to correctly retrieve macOS window insets.

### Result

- macOS: Toasts now respect the top window chrome and appear with correct padding.
- iOS: Unchanged (uses existing UIKit logic).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Toast notifications now support macOS with platform-specific safe area inset handling. The component calculates layout insets correctly on macOS while maintaining complete backward compatibility with existing iOS implementations, ensuring notifications display consistently and correctly positioned relative to system UI elements and safe area boundaries across all supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->