### PR TITLE
Adjust ToastView padding for safe areas on iOS and macOS

### DIFF
--- a/Sources/NoticeUI/ToastView.swift
+++ b/Sources/NoticeUI/ToastView.swift
@@ -29,7 +29,11 @@ struct ToastView: View {
                 switch toast.placement {
                 case .top:
                     toastContent
+                        #if os(macOS)
                         .padding(.top, safeArea.top + 16)
+                        #else
+                        .padding(.top, safeArea.top + 4)
+                        #endif
                     Spacer()
                 case .center:
                     Spacer()
@@ -38,7 +42,7 @@ struct ToastView: View {
                 case .bottom:
                     Spacer()
                     toastContent
-                        .padding(.bottom, safeArea.bottom + 16)
+                        .padding(.bottom, safeArea.bottom > 0 ? safeArea.bottom + 4 : 16)
                 }
             }
             .frame(width: geometry.size.width, height: geometry.size.height)


### PR DESCRIPTION
Closes #6

### Description
This PR addresses inconsistent vertical padding for toasts on different devices and platforms.

- **iOS:** Adjusts top padding to use safeArea.top + 4 instead of a larger fixed value, preventing excessive spacing on modern iPhones with notches/dynamic islands while maintaining safe clearances.
- **macOS:** Adds platform-specific logic to use safeArea.top + 16, ensuring toasts don't overlap with window controls or the menu bar area.
- **Bottom Padding:** Dynamic adjustment (safeArea.bottom + 4 or 16) ensures proper spacing above the home indicator on newer devices and sufficient margin on older devices.


### Changes

- Modified ToastView.swift to use conditional padding based on safeArea values and #if os(macOS) checks.


### Impact

- Toasts now look visually consistent and correctly positioned across iPhone 8, iPhone 14+, and macOS.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved toast notification padding behavior to account for platform-specific safe area insets, enhancing positioning consistency across different devices and platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->